### PR TITLE
Fixed steering on the ground.

### DIFF
--- a/spitfireVb.xml
+++ b/spitfireVb.xml
@@ -426,23 +426,8 @@ gear-ratio = "0.477" moment = 37.15-->
 									 src0="0"
 									 src1="1"
 									 dst0="1"
-									 dst1="1"
+									 dst1="0"
 									 control="CASTERING"/>
-	</gear>
-	<!-- dummy Tail wheel - add a little friction to make it flyable!  -->
-	<gear x="-8.48"
-				y="0"
-				z="-0.66"
-				compression="0.15"
-				dfric="0.7"
-				sfric ="0.8">
-		<control-input axis="/controls/flight/elevator"
-									 control="BRAKE"
-									 transition-time="0"
-									 src0="-1"
-									 src1="0"
-									 dst0="1"
-									 dst1="0"/>
 	</gear>
 
 	<!-- Canopy -->


### PR DESCRIPTION
There was an issue that prevented tail wheel locking from working: the tail wheel was always freely castering no matter the value of `/controls/gear/tailwheel-lock`. To work around this issue, there was a second tail wheel that was not castering, in effect this made for a permanently locked tail wheel and prevented steering while on the ground.

This pull request fixes the issue with locking of the main tail wheel and removes the extra wheel.
